### PR TITLE
Replace parser surface with a Parsec compatibility layer

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -93,7 +93,7 @@ main = do
         txt <- T.readFile fname
         case runParser parser fname txt
             :: Either (M.ParseErrorBundle T.Text Void) (Warnings, ASTs Integer, GlobalVars Integer, Literals Integer) of
-            Left x  -> print x -- putStr $ M.errorBundlePretty x
+            Left x  -> putStr $ M.errorBundlePretty x
             Right r -> do
                 mapM_ (hPutStr stderr . M.errorBundlePretty) $ toList $ fst4 r
                 runAsm' $ casm' (snd4 r) (thd4 r) (fou4 r)

--- a/htcc.cabal
+++ b/htcc.cabal
@@ -95,6 +95,10 @@ library
       Htcc.Parser.ConstructionData.Scope.Var
       Htcc.Parser.Utils
       Htcc.Parser.Utils.Core
+      Text.Megaparsec
+      Text.Megaparsec.Char
+      Text.Megaparsec.Char.Lexer
+      Text.Megaparsec.Debug
       Htcc.Tokenizer
       Htcc.Tokenizer.Core
       Htcc.Tokenizer.Token
@@ -123,7 +127,7 @@ library
     , diagrams-lib
     , diagrams-svg
     , extra
-    , megaparsec
+    , parsec
     , monad-finally
     , monad-loops
     , mono-traversable
@@ -159,7 +163,7 @@ executable htcc
     , extra
     , gitrev
     , htcc
-    , megaparsec
+    , parsec
     , monad-finally
     , monad-loops
     , mono-traversable
@@ -210,7 +214,7 @@ test-suite htcc-test
     , hspec-contrib
     , hspec-core
     , htcc
-    , megaparsec
+    , parsec
     , monad-finally
     , monad-loops
     , mono-traversable
@@ -247,7 +251,7 @@ benchmark criterion
     , diagrams-svg
     , extra
     , htcc
-    , megaparsec
+    , parsec
     , monad-finally
     , monad-loops
     , mono-traversable

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ dependencies:
 - diagrams-lib
 - natural-transformation
 - optparse-applicative
-- megaparsec
+- parsec
 - parser-combinators
 - utf8-string
 

--- a/src/Htcc/Parser/Combinators/Core.hs
+++ b/src/Htcc/Parser/Combinators/Core.hs
@@ -66,30 +66,36 @@ import           Htcc.Utils                         (lor)
 import qualified Text.Megaparsec                    as M
 import qualified Text.Megaparsec.Char               as MC
 import qualified Text.Megaparsec.Char.Lexer         as ML
+import qualified Text.Parsec                        as P
 
-spaceConsumer :: Ord e => M.ParsecT e T.Text m ()
+spaceConsumer :: (Monad m, Ord e) => M.ParsecT e T.Text m ()
 spaceConsumer = ML.space MC.space1 (ML.skipLineComment "//") (ML.skipBlockComment "/*" "*/")
 
-lexeme :: Ord e => M.ParsecT e T.Text m a -> M.ParsecT e T.Text m a
+lexeme :: (Monad m, Ord e) => M.ParsecT e T.Text m a -> M.ParsecT e T.Text m a
 lexeme = ML.lexeme spaceConsumer
 
-symbol :: Ord e => T.Text -> M.ParsecT e T.Text m T.Text
+symbol :: (Monad m, Ord e) => T.Text -> M.ParsecT e T.Text m T.Text
 symbol = ML.symbol spaceConsumer
 
-charLiteral :: Ord e => M.ParsecT e T.Text m Char
-charLiteral = M.between (MC.char '\'') (MC.char '\'') ML.charLiteral <* spaceConsumer
+charLiteral :: (Monad m, Ord e) => M.ParsecT e T.Text m Char
+charLiteral = M.between (MC.char '\'') (MC.char '\'') charBody <* spaceConsumer
+    where
+        -- Keep the historical single-quoted character behavior that the existing
+        -- component tests exercise, while `ML.charLiteral` remains strict enough
+        -- for string-literal parsing.
+        charBody = ML.charLiteral <|> M.ParsecT (P.noneOf ['\\'])
 
-stringLiteral :: Ord e => M.ParsecT e T.Text m String
+stringLiteral :: (Monad m, Ord e) => M.ParsecT e T.Text m String
 stringLiteral = MC.char '\"' *> ((<> "\0") <$> M.manyTill ML.charLiteral (MC.char '\"')) <* spaceConsumer
 
-hexadecimal, octal, decimal, natural, integer :: (Ord e, Num i) => M.ParsecT e T.Text m i
+hexadecimal, octal, decimal, natural, integer :: (Monad m, Ord e, Num i) => M.ParsecT e T.Text m i
 hexadecimal = MC.char '0' >> MC.char' 'x' >> ML.hexadecimal
 octal = MC.char '0' >> ML.octal
 decimal = ML.decimal
 natural = M.try (lexeme hexadecimal) <|> M.try (lexeme octal) <|> lexeme decimal
 integer = ML.signed spaceConsumer natural <|> natural
 
-parens, braces, angles, brackets :: Ord e => M.ParsecT e T.Text m a -> M.ParsecT e T.Text m a
+parens, braces, angles, brackets :: (Monad m, Ord e) => M.ParsecT e T.Text m a -> M.ParsecT e T.Text m a
 parens = between lparen rparen
 braces = between lbrace rbrace
 angles = between langle rangle
@@ -118,7 +124,7 @@ identifier,
     hat,
     tilda,
     vertical,
-    percent :: Ord e => M.ParsecT e T.Text m T.Text
+    percent :: (Monad m, Ord e) => M.ParsecT e T.Text m T.Text
 identifier =
     mappend
         <$> M.takeWhile1P (Just "valid identifier") (lor [isAlpha, (=='_')])
@@ -148,7 +154,7 @@ tilda = symbol "~"
 vertical = symbol "|"
 percent = symbol "%"
 
-notFollowedBy :: Ord e
+notFollowedBy :: (Monad m, Ord e)
     => M.ParsecT e T.Text m a
     -> M.ParsecT e T.Text m b
     -> M.ParsecT e T.Text m a

--- a/src/Htcc/Parser/Combinators/Keywords.hs
+++ b/src/Htcc/Parser/Combinators/Keywords.hs
@@ -27,7 +27,7 @@ import           Htcc.Parser.Combinators.Core
 import qualified Text.Megaparsec              as M
 import qualified Text.Megaparsec.Char         as MC
 
-pKeyword :: Ord e => T.Text -> M.ParsecT e T.Text m T.Text
+pKeyword :: (Monad m, Ord e) => T.Text -> M.ParsecT e T.Text m T.Text
 pKeyword = flip notFollowedBy (M.takeWhile1P (Just "valid Keyword") CR.isValidChar) . MC.string
 
 kAuto, kBreak, kCase, kChar, kConst, kContinue,
@@ -37,7 +37,7 @@ kAuto, kBreak, kCase, kChar, kConst, kContinue,
     kSizeof, kStatic, kStruct, kSwitch, kTypedef, kUnion,
     kUnsigned, kVoid, kVolatile, kWhile, k_Alignas, k_Alignof,
     k_Atomic, k_Bool, k_Complex, k_Generic, k_Imaginary, k_Noreturn,
-    k_Static_assert, k_Thread_local :: Ord e => M.ParsecT e T.Text m T.Text
+    k_Static_assert, k_Thread_local :: (Monad m, Ord e) => M.ParsecT e T.Text m T.Text
 kAuto = pKeyword "auto"
 kBreak = pKeyword "break"
 kCase = pKeyword "case"
@@ -83,7 +83,7 @@ k_Noreturn = pKeyword "_Noreturn"
 k_Static_assert = pKeyword "_Static_assert"
 k_Thread_local = pKeyword "_Thread_local"
 
-kBasicTypes :: Ord e => [M.ParsecT e T.Text m T.Text]
+kBasicTypes :: (Monad m, Ord e) => [M.ParsecT e T.Text m T.Text]
 kBasicTypes = [
     kChar
   , kDouble
@@ -98,4 +98,3 @@ kBasicTypes = [
   , k_Complex
   , k_Imaginary
   ]
-

--- a/src/Text/Megaparsec.hs
+++ b/src/Text/Megaparsec.hs
@@ -1,0 +1,242 @@
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving,
+             LambdaCase, MultiParamTypeClasses, UndecidableInstances #-}
+module Text.Megaparsec (
+    Parsec,
+    ParsecT (..),
+    ParseErrorBundle (..),
+    ParseError (..),
+    ErrorFancy (..),
+    PosState (..),
+    ParserState (..),
+    runParser,
+    runParserT,
+    errorBundlePretty,
+    try,
+    lookAhead,
+    option,
+    choice,
+    many,
+    manyTill,
+    eof,
+    between,
+    takeWhileP,
+    takeWhile1P,
+    notFollowedBy,
+    getInput,
+    setInput,
+    getSourcePos,
+    getParserState,
+    withRecovery,
+    parseError,
+    empty,
+    (<|>)
+) where
+
+import           Control.Applicative       (Alternative (..), many, (<|>))
+import           Control.Monad             (MonadPlus)
+import qualified Control.Monad.State.Class as MS
+import           Control.Monad.Trans.Class (MonadTrans (..))
+import           Data.Bool                 (bool)
+import           Data.Foldable             (toList)
+import           Data.Functor.Identity     (Identity, runIdentity)
+import           Data.List                 (intercalate)
+import           Data.List.NonEmpty        (NonEmpty ((:|)))
+import qualified Data.Set                  as S
+import qualified Data.Text                 as T
+import qualified Text.Parsec               as P
+import qualified Text.Parsec.Error         as PE
+import qualified Text.Parsec.Pos           as PP
+import qualified Text.Parsec.Prim          as PPri
+
+newtype ParsecT e s m a = ParsecT
+    { unParsecT :: P.ParsecT s s m a
+    }
+    deriving (Functor, Applicative, Monad, Alternative, MonadPlus, MonadFail)
+
+instance MonadTrans (ParsecT e s) where
+    lift = ParsecT . lift
+
+instance MS.MonadState st m => MS.MonadState st (ParsecT e s m) where
+    get = lift MS.get
+    put = lift . MS.put
+    state = lift . MS.state
+
+type Parsec e s = ParsecT e s Identity
+
+data ErrorFancy e
+    = ErrorFail String
+    deriving (Eq, Ord, Show)
+
+data ParseError s e
+    = ParsecError Bool PE.ParseError
+    | FancyError Int (S.Set (ErrorFancy e))
+    deriving (Eq, Show)
+
+data PosState s = PosState
+    { pstateInput     :: s
+    , pstateSourcePos :: PP.SourcePos
+    }
+    deriving (Eq, Show)
+
+data ParserState s = ParserState
+    { statePosState :: PosState s
+    }
+    deriving (Eq, Show)
+
+data ParseErrorBundle s e = ParseErrorBundle
+    { bundleErrors   :: NonEmpty (ParseError s e)
+    , bundlePosState :: PosState s
+    }
+    deriving (Eq)
+
+instance Show (ParseErrorBundle T.Text e) where
+    show = errorBundlePretty
+
+runParser :: Parsec e T.Text a -> FilePath -> T.Text -> Either (ParseErrorBundle T.Text e) a
+runParser p fp input = runIdentity $ runParserT p fp input
+
+runParserT :: Monad m => ParsecT e T.Text m a -> FilePath -> T.Text -> m (Either (ParseErrorBundle T.Text e) a)
+runParserT (ParsecT p) fp input =
+    fmap (either (Left . toBundle input) Right) $
+        P.runParserT p input fp input
+    where
+        toBundle source err =
+            ParseErrorBundle
+                { bundleErrors = ParsecError False err :| []
+                , bundlePosState = PosState source (PE.errorPos err)
+                }
+
+errorBundlePretty :: ParseErrorBundle T.Text e -> String
+errorBundlePretty bundle =
+    intercalate "\n\n" (fmap renderError $ toList $ bundleErrors bundle) <> "\n"
+    where
+        renderError = \case
+            ParsecError _ err ->
+                renderAt (PE.errorPos err) $
+                    lines $
+                        PE.showErrorMessages
+                            "or"
+                            "unknown parse error"
+                            "expecting"
+                            "unexpected"
+                            "end of input"
+                            (PE.errorMessages err)
+            FancyError _ fancyErrors ->
+                renderAt
+                    (pstateSourcePos $ bundlePosState bundle)
+                    [ msg
+                    | ErrorFail msg <- S.toList fancyErrors
+                    ]
+
+        renderAt pos msgs =
+            intercalate "\n" $
+                [ renderLoc pos ]
+                    <> maybe [] (\(srcLn, caretCol) -> [srcLn, replicate (pred caretCol) ' ' <> "^"]) (sourceLineAt pos)
+                    <> msgs
+
+        renderLoc pos =
+            intercalate
+                ":"
+                [ PP.sourceName pos
+                , show $ PP.sourceLine pos
+                , show $ PP.sourceColumn pos
+                ]
+
+        sourceLineAt pos =
+            let lineNo = fromIntegral (PP.sourceLine pos) - 1
+                inputLines = T.splitOn (T.singleton '\n') $ pstateInput $ bundlePosState bundle
+             in if lineNo < 0
+                    then Nothing
+                    else case drop lineNo inputLines of
+                        srcLn : _ -> Just (T.unpack srcLn, fromIntegral $ PP.sourceColumn pos)
+                        []        -> Nothing
+
+try :: ParsecT e T.Text m a -> ParsecT e T.Text m a
+try = ParsecT . P.try . unParsecT
+
+lookAhead :: Monad m => ParsecT e T.Text m a -> ParsecT e T.Text m a
+lookAhead = ParsecT . P.lookAhead . unParsecT
+
+option :: Monad m => a -> ParsecT e T.Text m a -> ParsecT e T.Text m a
+option x = ParsecT . P.option x . unParsecT
+
+choice :: Alternative f => [f a] -> f a
+choice = foldr (<|>) empty
+
+manyTill :: Monad m => ParsecT e T.Text m a -> ParsecT e T.Text m end -> ParsecT e T.Text m [a]
+manyTill p end = ParsecT $ P.manyTill (unParsecT p) (unParsecT end)
+
+eof :: Monad m => ParsecT e T.Text m ()
+eof = ParsecT P.eof
+
+between :: Monad m => ParsecT e T.Text m open -> ParsecT e T.Text m close -> ParsecT e T.Text m a -> ParsecT e T.Text m a
+between open close parser = ParsecT $
+    P.between (unParsecT open) (unParsecT close) (unParsecT parser)
+
+takeWhileP :: Monad m => Maybe String -> (Char -> Bool) -> ParsecT e T.Text m T.Text
+takeWhileP _ predicate = ParsecT $ T.pack <$> P.many (P.satisfy predicate)
+
+takeWhile1P :: Monad m => Maybe String -> (Char -> Bool) -> ParsecT e T.Text m T.Text
+takeWhile1P _ predicate = ParsecT $ T.pack <$> P.many1 (P.satisfy predicate)
+
+notFollowedBy :: Monad m => ParsecT e T.Text m a -> ParsecT e T.Text m ()
+notFollowedBy parser = ParsecT $
+    P.optionMaybe (P.try $ P.lookAhead $ unParsecT parser) >>= \case
+        Just _ -> P.unexpected "unexpected trailing input"
+        Nothing -> pure ()
+
+getInput :: Monad m => ParsecT e T.Text m T.Text
+getInput = ParsecT P.getInput
+
+setInput :: Monad m => T.Text -> ParsecT e T.Text m ()
+setInput = ParsecT . P.setInput
+
+getSourcePos :: Monad m => ParsecT e T.Text m PP.SourcePos
+getSourcePos = ParsecT P.getPosition
+
+getParserState :: Monad m => ParsecT e T.Text m (ParserState T.Text)
+getParserState = ParsecT $ do
+    input <- P.getState
+    pos <- P.getPosition
+    pure $ ParserState (PosState input pos)
+
+withRecovery
+    :: Monad m
+    => (ParseError T.Text e -> ParsecT e T.Text m a)
+    -> ParsecT e T.Text m a
+    -> ParsecT e T.Text m a
+withRecovery handler parser = ParsecT $ PPri.mkPT $ \state ->
+    PPri.runParsecT (unParsecT parser) state >>= \case
+        PPri.Consumed replyM -> pure . PPri.Consumed $ replyM >>= \case
+            ok@(PPri.Ok _ _ _) -> pure ok
+            PPri.Error err ->
+                PPri.runParsecT (unParsecT $ handler $ ParsecError True err) (recoveryState err state) >>= \case
+                    PPri.Consumed handledReply -> handledReply
+                    PPri.Empty handledReply    -> handledReply
+        PPri.Empty replyM -> replyM >>= \case
+            ok@(PPri.Ok _ _ _) -> pure $ PPri.Empty (pure ok)
+            PPri.Error err -> PPri.runParsecT (unParsecT $ handler $ ParsecError False err) (recoveryState err state)
+    where
+        recoveryState err parserState =
+            parserState
+                { PPri.stateInput = remainingInput (PPri.statePos parserState) (PPri.stateInput parserState)
+                , PPri.statePos = PE.errorPos err
+                }
+            where
+                targetPos = PE.errorPos err
+                remainingInput pos input
+                    | pos == targetPos = input
+                    | otherwise =
+                        maybe T.empty advance $ T.uncons input
+                    where
+                        advance (c, rest) = remainingInput (PP.updatePosChar pos c) rest
+
+parseError :: Monad m => ParseError s e -> ParsecT e s m a
+parseError = ParsecT . \case
+    ParsecError consumed err -> PPri.mkPT $ \_ -> pure $
+        bool
+            (PPri.Empty $ pure $ PPri.Error err)
+            (PPri.Consumed $ pure $ PPri.Error err)
+            consumed
+    FancyError _ fancyErrors -> fail $
+        intercalate ", " [msg | ErrorFail msg <- S.toList fancyErrors]

--- a/src/Text/Megaparsec/Char.hs
+++ b/src/Text/Megaparsec/Char.hs
@@ -1,0 +1,25 @@
+module Text.Megaparsec.Char (
+    char,
+    char',
+    string,
+    space1
+) where
+
+import           Control.Monad   (void)
+import           Data.Char       (isSpace, toLower)
+import qualified Data.Text       as T
+import qualified Text.Parsec     as P
+
+import           Text.Megaparsec (ParsecT (..))
+
+char :: Monad m => Char -> ParsecT e T.Text m Char
+char = ParsecT . P.char
+
+char' :: Monad m => Char -> ParsecT e T.Text m Char
+char' c = ParsecT $ P.satisfy ((== toLower c) . toLower)
+
+string :: Monad m => T.Text -> ParsecT e T.Text m T.Text
+string = ParsecT . fmap T.pack . P.try . P.string . T.unpack
+
+space1 :: Monad m => ParsecT e T.Text m ()
+space1 = ParsecT $ void $ P.many1 $ P.satisfy isSpace

--- a/src/Text/Megaparsec/Char/Lexer.hs
+++ b/src/Text/Megaparsec/Char/Lexer.hs
@@ -1,0 +1,112 @@
+module Text.Megaparsec.Char.Lexer (
+    space,
+    skipLineComment,
+    skipBlockComment,
+    lexeme,
+    symbol,
+    charLiteral,
+    decimal,
+    hexadecimal,
+    octal,
+    signed
+) where
+
+import           Control.Applicative  ((<|>))
+import           Control.Monad        (void)
+import           Data.Char            (chr, isHexDigit, isOctDigit)
+import qualified Data.Text            as T
+import           Numeric              (readHex, readOct)
+import qualified Text.Parsec          as P
+
+import           Text.Megaparsec      (ParsecT (..))
+import qualified Text.Megaparsec.Char as MC
+
+space :: Monad m => ParsecT e T.Text m () -> ParsecT e T.Text m () -> ParsecT e T.Text m () -> ParsecT e T.Text m ()
+space sp lineComment blockComment = ParsecT $
+    P.skipMany $ P.try (unParsecT sp) <|> P.try (unParsecT lineComment) <|> unParsecT blockComment
+
+skipLineComment :: Monad m => T.Text -> ParsecT e T.Text m ()
+skipLineComment prefix = ParsecT $
+    void $ P.try (unParsecT $ MC.string prefix) *> P.many (P.noneOf "\n")
+
+skipBlockComment :: Monad m => T.Text -> T.Text -> ParsecT e T.Text m ()
+skipBlockComment start end = ParsecT $
+    void $ P.try (unParsecT $ MC.string start) *> P.manyTill P.anyChar (P.try $ unParsecT $ MC.string end)
+
+lexeme :: Monad m => ParsecT e T.Text m () -> ParsecT e T.Text m a -> ParsecT e T.Text m a
+lexeme sc parser = ParsecT $ unParsecT parser <* unParsecT sc
+
+symbol :: Monad m => ParsecT e T.Text m () -> T.Text -> ParsecT e T.Text m T.Text
+symbol sc = lexeme sc . MC.string
+
+charLiteral :: Monad m => ParsecT e T.Text m Char
+charLiteral = ParsecT $ escaped <|> P.noneOf ['\\']
+    where
+        escaped =
+            P.char '\\'
+                *> (hexEscape
+                    <|> octalEscape
+                    <|> simpleEscape
+                    <|> invalidEscape
+                   )
+
+        simpleEscape = P.choice
+            [ '\a' <$ P.char 'a'
+            , '\b' <$ P.char 'b'
+            , '\t' <$ P.char 't'
+            , '\n' <$ P.char 'n'
+            , '\v' <$ P.char 'v'
+            , '\f' <$ P.char 'f'
+            , '\r' <$ P.char 'r'
+            , '\ESC' <$ P.char 'e'
+            , '\\' <$ P.char '\\'
+            , '\'' <$ P.char '\''
+            , '"' <$ P.char '"'
+            , '?' <$ P.char '?'
+            ]
+
+        hexEscape = do
+            digits <- P.char 'x' *> P.many1 (P.satisfy isHexDigit)
+            maybe invalidCodePoint pure $ decode readHex digits
+
+        octalEscape = do
+            digits <- octalDigits
+            maybe invalidCodePoint pure $ decode readOct digits
+
+        octalDigits =
+            (:) <$> P.satisfy isOctDigit <*> P.option [] (P.try $ P.count 2 (P.satisfy isOctDigit) <|> P.count 1 (P.satisfy isOctDigit))
+
+        decode :: (String -> [(Integer, String)]) -> String -> Maybe Char
+        decode reader digits = safeChr . fst =<< listToMaybe (reader digits)
+
+        listToMaybe []      = Nothing
+        listToMaybe (x : _) = Just x
+
+        safeChr n
+            | n < 0 = Nothing
+            | n > fromIntegral (fromEnum (maxBound :: Char)) = Nothing
+            | 0xD800 <= n && n <= 0xDFFF = Nothing
+            | otherwise = Just (chr $ fromIntegral n)
+
+        invalidEscape =
+            P.anyChar >>= \c -> fail ("invalid escape sequence \\" <> [c])
+
+        invalidCodePoint = fail "character code point out of range"
+
+decimal :: (Monad m, Num i) => ParsecT e T.Text m i
+decimal = ParsecT $ fromInteger . read <$> P.many1 P.digit
+
+hexadecimal :: (Monad m, Num i) => ParsecT e T.Text m i
+hexadecimal = ParsecT $
+    fromInteger . fst . head . (readHex :: String -> [(Integer, String)]) <$> P.many1 (P.satisfy isHexDigit)
+
+octal :: (Monad m, Num i) => ParsecT e T.Text m i
+octal = ParsecT $
+    fromInteger . fst . head . (readOct :: String -> [(Integer, String)]) <$> P.many1 (P.satisfy isOctDigit)
+
+signed :: (Monad m, Num i) => ParsecT e T.Text m () -> ParsecT e T.Text m i -> ParsecT e T.Text m i
+signed sc parser = ParsecT $ do
+    signFn <- P.option id $
+        P.try ((negate <$ P.char '-') <* unParsecT sc)
+            <|> P.try ((id <$ P.char '+') <* unParsecT sc)
+    signFn <$> unParsecT parser

--- a/src/Text/Megaparsec/Debug.hs
+++ b/src/Text/Megaparsec/Debug.hs
@@ -1,0 +1,6 @@
+module Text.Megaparsec.Debug (
+    dbg
+) where
+
+dbg :: String -> a -> a
+dbg _ = id


### PR DESCRIPTION
## Summary
- replace the Megaparsec dependency with `parsec` and provide local `Text.Megaparsec*` compatibility modules
- adapt parser combinators and CLI error handling to the compatibility layer without changing existing tests
- preserve diagnostic formatting by restoring trailing newlines in `errorBundlePretty` and avoiding bogus source-line fallback at EOF-after-newline

## Verification
- `STACK_ROOT=/tmp/htcc-stack3-root stack --docker --docker-image htcc-stack-bullseye:latest --docker-run-args='--platform linux/amd64' --docker-stack-exe download build --test --no-run-tests`
- `STACK_ROOT=/tmp/htcc-stack3-root stack --docker --docker-image htcc-stack-bullseye:latest --docker-run-args='--platform linux/amd64' --docker-stack-exe download test --test-arguments 'components'`
- `STACK_ROOT=/tmp/htcc-stack3-root stack --docker --docker-image htcc-stack-bullseye:latest --docker-run-args='--platform linux/amd64' --docker-stack-exe download test --test-arguments 'subp'`
- `STACK_ROOT=/tmp/htcc-stack3-root stack --docker --docker-image htcc-stack-bullseye:latest --docker-run-args='--platform linux/amd64' --docker-stack-exe download test --test-arguments 'self'`
- manual check: two warning diagnostics remain separated when compiling a sample with repeated undeclared function calls via `stack ... exec htcc -- <tmpfile>`

Closes #2.
